### PR TITLE
Fix help message on create subcommand

### DIFF
--- a/src/cmd/create/public.rs
+++ b/src/cmd/create/public.rs
@@ -9,7 +9,7 @@ use anyhow::bail;
 use openid::{Discovered, Options, StandardClaims};
 use std::path::PathBuf;
 
-/// Create a new confidential client
+/// Create a new public client
 #[derive(Debug, clap::Parser)]
 pub struct CreatePublic {
     #[command(flatten)]


### PR DESCRIPTION
I noticed this issue by running the CLI to look at the help messages, and saw that it output this:

```
$ ./result/bin/oidc create
Create a new client

Usage: oidc create [OPTIONS] <COMMAND>

Commands:
  confidential  Create a new confidential client
  public        Create a new confidential client
  help          Print this message or the help of the given subcommand(s)

Options:
  -q, --quiet            Be quiet, conflicts with 'verbose' [env: OIDC_QUIET=]
  -v, --verbose...       Be more verbose, conflicts with 'quiet' [env: OIDC_VERBOSE=]
  -c, --config <CONFIG>  Override config file [env: OIDC_CONFIG=]
  -h, --help             Print help
```

With this fix, we see that it's been resolved.

```
$ ./target/debug/oidc create
Create a new client

Usage: oidc create [OPTIONS] <COMMAND>

Commands:
  confidential  Create a new confidential client
  public        Create a new public client
  help          Print this message or the help of the given subcommand(s)

Options:
  -q, --quiet            Be quiet, conflicts with 'verbose' [env: OIDC_QUIET=]
  -v, --verbose...       Be more verbose, conflicts with 'quiet' [env: OIDC_VERBOSE=]
  -c, --config <CONFIG>  Override config file [env: OIDC_CONFIG=]
  -h, --help             Print help
```

I'm not typically a Rust developer, just noticed this issue and figured I'd toss a patch your way. 🙂