### PR TITLE
Enable openidconnect-rs feature to support non-compliant timestamps.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ directories = "6"
 humantime = "2"
 log = "0.4"
 open = "5"
-openidconnect = "4"
+openidconnect = { version = "4", features = ["accept-rfc3339-timestamps"] }
 oauth2 = "5"
 pretty-hex = "0.4.1"
 reqwest = "0.12"


### PR DESCRIPTION
This PR (related to #11) turns on a feature on the upstream `openidconnect-rs` to support non-compliant timestamps in an IDP responses.

Among others, it allows to use Auth0 as an IDP (which sends an invalid `updated_at` field.