### PR TITLE
fix: pass in provided URL instead of parsing it ourself

### DIFF
--- a/src/cmd/create/mod.rs
+++ b/src/cmd/create/mod.rs
@@ -2,7 +2,7 @@ mod confidential;
 mod public;
 
 use crate::cmd::create::{confidential::CreateConfidential, public::CreatePublic};
-use url::Url;
+use openidconnect::IssuerUrl;
 
 /// Create a new client
 #[derive(Debug, clap::Parser)]
@@ -32,12 +32,16 @@ pub struct CreateCommon {
     pub skip_initial: bool,
 
     /// URL of the issuer
-    #[arg(long)]
-    pub issuer: Url,
+    #[arg(long, value_parser(parse_issuer))]
+    pub issuer: IssuerUrl,
 
     /// Additional scope
     #[arg(short = 'S', long)]
     pub scope: Option<String>,
+}
+
+fn parse_issuer(s: &str) -> Result<IssuerUrl, anyhow::Error> {
+    Ok(IssuerUrl::new(s.to_string())?)
 }
 
 #[derive(Debug, clap::Subcommand)]

--- a/src/cmd/create/public.rs
+++ b/src/cmd/create/public.rs
@@ -12,7 +12,7 @@ use oauth2::{
     EndpointSet, PkceCodeChallenge, RedirectUrl, TokenResponse,
 };
 use openidconnect::{
-    AuthenticationFlow, IssuerUrl, Nonce,
+    AuthenticationFlow, Nonce,
     core::{CoreClient, CoreProviderMetadata, CoreResponseType, CoreTokenResponse},
 };
 use std::path::PathBuf;
@@ -86,11 +86,8 @@ impl CreatePublic {
 
         let http = create_client(&self.http).await?;
 
-        let provider_metadata = CoreProviderMetadata::discover_async(
-            IssuerUrl::from_url(self.common.issuer.clone()),
-            &http,
-        )
-        .await?;
+        let provider_metadata =
+            CoreProviderMetadata::discover_async(self.common.issuer.clone(), &http).await?;
 
         let client = CoreClient::from_provider_metadata(
             provider_metadata,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -8,6 +8,7 @@ mod token;
 use std::process::ExitCode;
 
 #[derive(Debug, clap::Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Command {
     Create(create::Create),
     Delete(delete::Delete),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, anyhow};
 use oauth2::TokenResponse;
+use openidconnect::IssuerUrl;
 use openidconnect::core::CoreTokenResponse;
 use std::{
     collections::BTreeMap,
@@ -7,7 +8,6 @@ use std::{
     io::{BufReader, BufWriter, ErrorKind},
     path::{Path, PathBuf},
 };
-use url::Url;
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct Config {
@@ -83,7 +83,7 @@ impl Config {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Client {
-    pub issuer_url: Url,
+    pub issuer_url: IssuerUrl,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<String>,
     pub r#type: ClientType,

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, bail};
 use biscuit::{Empty, jws::Compact};
 use oauth2::{EndpointMaybeSet, EndpointNotSet, EndpointSet, RefreshToken};
 use openidconnect::{
-    Audience, ClientId, ClientSecret, IssuerUrl, Scope,
+    Audience, ClientId, ClientSecret, Scope,
     core::{CoreClient, CoreProviderMetadata, CoreTokenResponse},
 };
 use time::OffsetDateTime;
@@ -29,11 +29,8 @@ pub async fn fetch_token(config: &Client, http: &HttpOptions) -> anyhow::Result<
             client_id,
             client_secret,
         } => {
-            let provider_metadata = CoreProviderMetadata::discover_async(
-                IssuerUrl::from_url(config.issuer_url.clone()),
-                &http,
-            )
-            .await?;
+            let provider_metadata =
+                CoreProviderMetadata::discover_async(config.issuer_url.clone(), &http).await?;
 
             let client = CoreClient::from_provider_metadata(
                 provider_metadata,
@@ -59,11 +56,8 @@ pub async fn fetch_token(config: &Client, http: &HttpOptions) -> anyhow::Result<
                 );
             };
 
-            let provider_metadata = CoreProviderMetadata::discover_async(
-                IssuerUrl::from_url(config.issuer_url.clone()),
-                &http,
-            )
-            .await?;
+            let provider_metadata =
+                CoreProviderMetadata::discover_async(config.issuer_url.clone(), &http).await?;
 
             let refresh_token = state.refresh_token.clone().ok_or_else(|| anyhow!("Expired token of a public client, without having a refresh token. You will need to re-login."))?;
 


### PR DESCRIPTION
This is required because parsing the URL ourselves might normalize certain parts, but then the OIDC validation might fail because it works with non-normalized versions of the URL.

Closes: #19